### PR TITLE
Add Cursor Rules!

### DIFF
--- a/.cursor/rules/create-new-vue-motion-icon.mdc
+++ b/.cursor/rules/create-new-vue-motion-icon.mdc
@@ -1,0 +1,152 @@
+---
+description: 
+globs: app/components/Lucide/*.vue
+alwaysApply: false
+---
+# Converting React Lucide Icons to Vue: Guide
+
+Here's a step-by-step guide for converting React animated Lucide icons to Vue components in this project:
+
+## 1. Basic Structure
+
+```vue
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+// Define animation variants here
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg>
+      <!-- SVG elements here -->
+    </svg>
+  </div>
+</template>
+```
+
+## 2. Animation Pattern Conversion
+
+When converting React motion animations to Vue:
+
+| React | Vue |
+|-------|-----|
+| `animate={controls}` | `:animate="currentState"` |
+| `variants={...}` | `:variants="iconVariants"` |
+| `<motion.svg>` | `<svg>` with `<motion.path>` inside |
+| `transition={{ ... }}` | Include in each variant or as separate prop |
+
+## 3. Converting Animation Arrays
+
+- Keep animation arrays in the same format: `[val1, val2, val3, ...]`
+- Include all keyframe points from React
+- Use `duration` and `bounce` parameters for spring animations
+- For complex keyframes, use `transition` inside the variant
+
+Example:
+```typescript
+const searchVariants = {
+  normal: { 
+    x: 0, 
+    y: 0,
+    transition: {
+      duration: 0.3,
+      type: 'spring',
+      stiffness: 400,
+      damping: 25
+    }
+  },
+  animate: { 
+    x: [0, 0, -3, 0],  // Same array as React
+    y: [0, -4, 0, 0],  // Same array as React
+    transition: {
+      duration: 1,
+      bounce: 0.3      // Same as React
+    }
+  }
+};
+```
+
+## 4. SVG Path Conversion
+
+- Use `motion.path`, `motion.circle`, etc. for elements that need animation
+- Keep all SVG attributes the same (viewBox, fill, stroke, etc.)
+- Add `style="overflow: visible"` to the SVG element if needed
+
+## 5. Adding to index.vue
+
+After creating a new icon component in `app/components/Lucide/`, add it to `app/pages/index.vue`:
+
+```vue
+<AnimatedIconButton>
+  <template #default="{ ref, controlled }">
+    <LucideYourNewIcon
+      :ref="ref"
+      :controlled="controlled"
+      :class="primaryColor"
+    />
+  </template>
+</AnimatedIconButton>
+```
+
+## Common Gotchas
+
+1. Don't use arrays with spring animations for x/y - use only two keyframes or keyframes with tween animations
+2. Remember all Vue components in the Lucide directory are auto-imported with the "Lucide" prefix
+3. Ignore TypeScript errors about `motion-v` - they appear in all components
+4. Keep animations simple - one normal state and one animate state
+5. Don't add unnecessary timers or complex logic - just toggle the state

--- a/app/components/Lucide/BluetoothSearching.vue
+++ b/app/components/Lucide/BluetoothSearching.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    scale: 1,
+    transition: {
+      repeat: 0,
+    },
+  },
+  animate: {
+    scale: [0, 1, 0.8],
+    transition: {
+      duration: 0.6,
+      repeat: Infinity,
+    },
+  },
+};
+
+const secondVariants = {
+  normal: {
+    opacity: 1,
+  },
+  animate: {
+    opacity: [1, 0.8, 1],
+    transition: { 
+      repeat: Infinity 
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      style="overflow: visible"
+    >
+      <motion.path
+        d="m7 7 10 10-5 5V2l5 5L7 17"
+        :variants="secondVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M20.83 14.83a4 4 0 0 0 0-5.66"
+        :variants="pathVariants"
+        :animate="currentState"
+        :transition="{
+          duration: 0.6,
+          delay: 0.2,
+          repeat: Infinity,
+        }"
+      />
+      <motion.path
+        d="M18 12h.01"
+        :variants="pathVariants"
+        :animate="currentState"
+        :transition="{
+          duration: 0.6,
+          repeat: Infinity,
+        }"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/SmartphoneCharging.vue
+++ b/app/components/Lucide/SmartphoneCharging.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: { 
+    opacity: 1 
+  },
+  animate: {
+    opacity: [1, 0.4, 1],
+    transition: {
+      duration: 1,
+      repeat: Infinity,
+      ease: 'easeInOut',
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      style="overflow: visible"
+    >
+      <rect width="14" height="20" x="5" y="2" rx="2" ry="2" />
+      <motion.path
+        d="M12.667 8 10 12h4l-2.667 4"
+        :variants="pathVariants"
+        :initial="'normal'"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -173,6 +173,24 @@
           />
         </template>
       </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideBluetoothSearching
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSmartphoneCharging
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
     </div>
   </UContainer>
 </template>


### PR DESCRIPTION
## ✨ Add `cursorrules` and Example Icon Conversion

### What’s Included
- Initialized `cursorrules` to enable automatic React → Vue icon conversion via Cursor.
- Added a **sample file** at:

```bash
app/components/Lucide/Index.vue
```

> This is required for Cursor to detect and trigger the conversion logic.

---

### 🪄 How to Use

1. Visit [https://icons.pqoqubbw.dev/](https://icons.pqoqubbw.dev/)  
2. Copy the **React code** of any icon.
3. Add any icon to cursor agent for context i.e. `app/components/Lucide/Delete.vue`
4. Then just paste the React code into cursor agent chat without any additional prompt
5. Cursor rule will automatically kickin and convert the component into a Vue file and save it properly.

---

### Why This Matters
This sets the groundwork for efficiently converting all Lucide icons to Vue with minimal effort — just copy, paste, and go!

**Note:** I added two icons perfectly with just copy and pasting the code from the React versions. So it works great!
