### PR TITLE
55 new icons

### DIFF
--- a/app/components/Lucide/AArrowUp.vue
+++ b/app/components/Lucide/AArrowUp.vue
@@ -16,27 +16,21 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const letterVariants = {
+  normal: { opacity: 1, scale: 1 },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    scale: [0.8, 1],
+    transition: { duration: 0.3 },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+const arrowVariants = {
+  normal: { opacity: 1, y: 0 },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
-    pathOffset: [1, 0],
+    y: [10, 0], // Changed from [-10, 0] to animate upward
+    transition: { duration: 0.3, delay: 0.2 },
   },
 };
 
@@ -93,32 +87,28 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <!-- Letter A - unchanged -->
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M3.5 13h6"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :variants="letterVariants"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="m2 16 4.5-9 4.5 9"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :variants="letterVariants"
+      />
+      <!-- Arrow pointing up - modified -->
+      <motion.path
+        d="M18 16V7"
+        :animate="currentState"
+        :variants="arrowVariants"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        d="m14 11 4-4 4 4"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :variants="arrowVariants"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/AirVent.vue
+++ b/app/components/Lucide/AirVent.vue
@@ -16,28 +16,27 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
+const windVariants = {
+  normal: (custom: unknown) => ({
     pathLength: 1,
     opacity: 1,
     pathOffset: 0,
-  },
-  animate: {
+    transition: {
+      duration: 0.3,
+      ease: 'easeInOut',
+      delay: custom as number,
+    },
+  }),
+  animate: (custom: unknown) => ({
     pathLength: [0, 1],
     opacity: [0, 1],
     pathOffset: [1, 0],
-  },
+    transition: {
+      duration: 0.5,
+      ease: 'easeInOut',
+      delay: custom as number,
+    },
+  }),
 };
 
 const isControlled = ref(false);
@@ -93,32 +92,20 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <path d="M6 12H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+      <path d="M6 8h12" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M18.3 17.7a2.5 2.5 0 0 1-3.16 3.83 2.53 2.53 0 0 1-1.14-2V12"
+        :variants="windVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="0"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M6.6 15.6A2 2 0 1 0 10 17v-5"
+        :variants="windVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :custom="0.2"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigDown.vue
+++ b/app/components/Lucide/ArrowBigDown.vue
@@ -16,27 +16,14 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'M15 6v6h4l-7 7-7-7h4V6h6z', translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: 'M15 6v6h4l-7 7-7-7h4V6h6z',
+    translateY: [0, +3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -94,31 +81,10 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M15 6v6h4l-7 7-7-7h4V6h6z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigDownDash.vue
+++ b/app/components/Lucide/ArrowBigDownDash.vue
@@ -16,27 +16,23 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const dashVariants = {
+  normal: { translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    translateY: [0, 1, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+const arrowVariants = {
+  normal: { translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    translateY: [0, 3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -93,32 +89,12 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <motion.path d="M15 5H9" :variants="dashVariants" :animate="currentState" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M15 9v3h4l-7 7-7-7h4V9z"
+        :variants="arrowVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigLeft.vue
+++ b/app/components/Lucide/ArrowBigLeft.vue
@@ -16,27 +16,14 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'M18 15h-6v4l-7-7 7-7v4h6v6z', translateX: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: 'M18 15h-6v4l-7-7 7-7v4h6v6z',
+    translateX: [0, -3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -94,31 +81,10 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M18 15h-6v4l-7-7 7-7v4h6v6z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigLeftDash.vue
+++ b/app/components/Lucide/ArrowBigLeftDash.vue
@@ -16,27 +16,23 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const dashVariants = {
+  normal: { translateX: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    translateX: [0, -1, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+const arrowVariants = {
+  normal: { translateX: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    translateX: [0, -3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -93,32 +89,12 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <motion.path d="M19 15V9" :variants="dashVariants" :animate="currentState" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M15 15h-3v4l-7-7 7-7v4h3v6z"
+        :variants="arrowVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigRight.vue
+++ b/app/components/Lucide/ArrowBigRight.vue
@@ -16,27 +16,14 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'M6 9h6V5l7 7-7 7v-4H6V9z', translateX: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: 'M6 9h6V5l7 7-7 7v-4H6V9z',
+    translateX: [0, 3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -94,31 +81,10 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M6 9h6V5l7 7-7 7v-4H6V9z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigRightDash.vue
+++ b/app/components/Lucide/ArrowBigRightDash.vue
@@ -16,27 +16,23 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const dashVariants = {
+  normal: { translateX: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    translateX: [0, 1, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+const arrowVariants = {
+  normal: { translateX: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    translateX: [0, 3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -93,32 +89,12 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <motion.path d="M5 9v6" :variants="dashVariants" :animate="currentState" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M9 9h3V5l7 7-7 7v-4H9V9z"
+        :variants="arrowVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigUp.vue
+++ b/app/components/Lucide/ArrowBigUp.vue
@@ -16,27 +16,14 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'M9 18v-6H5l7-7 7 7h-4v6H9z', translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: 'M9 18v-6H5l7-7 7 7h-4v6H9z',
+    translateY: [0, -3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -94,31 +81,10 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M9 18v-6H5l7-7 7 7h-4v6H9z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowBigUpDash.vue
+++ b/app/components/Lucide/ArrowBigUpDash.vue
@@ -16,27 +16,23 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const dashVariants = {
+  normal: { translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    translateY: [0, -1, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+const arrowVariants = {
+  normal: { translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    translateY: [0, -3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -93,32 +89,12 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <motion.path d="M9 19h6" :variants="dashVariants" :animate="currentState" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M9 15v-3H5l7-7 7 7h-4v3H9z"
+        :variants="arrowVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowDown.vue
+++ b/app/components/Lucide/ArrowDown.vue
@@ -16,27 +16,24 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const pathVariants = {
+  normal: { d: 'm19 12-7 7-7-7', translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    d: 'm19 12-7 7-7-7',
+    translateY: [0, -3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+const secondPathVariants = {
+  normal: { d: 'M12 5v14' },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: ['M12 5v14', 'M12 5v9', 'M12 5v14'],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -94,31 +91,15 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="m19 12-7 7-7-7"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M12 5v14"
+        :variants="secondPathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ArrowUp.vue
+++ b/app/components/Lucide/ArrowUp.vue
@@ -16,27 +16,24 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const pathVariants = {
+  normal: { d: 'm5 12 7-7 7 7', translateY: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    d: 'm5 12 7-7 7 7',
+    translateY: [0, 3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+const secondPathVariants = {
+  normal: { d: 'M12 19V5' },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: ['M12 19V5', 'M12 19V10', 'M12 19V5'],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -94,31 +91,15 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="m5 12 7-7 7 7"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M12 19V5"
+        :variants="secondPathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Cart.vue
+++ b/app/components/Lucide/Cart.vue
@@ -16,27 +16,16 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const cartVariants = {
+  normal: { scale: 1 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    scale: 1.1,
+    y: [0, -5, 0],
+    transition: {
+      duration: 0.3,
+      ease: 'easeInOut',
+      y: { repeat: 1, delay: 0.1, duration: 0.4 },
+    },
   },
 };
 
@@ -82,7 +71,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +81,10 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :variants="cartVariants"
+      :animate="currentState"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M6.29977 5H21L19 12H7.37671M20 16H8L6 3H3M9 20C9 20.5523 8.55228 21 8 21C7.44772 21 7 20.5523 7 20C7 19.4477 7.44772 19 8 19C8.55228 19 9 19.4477 9 20ZM20 20C20 20.5523 19.5523 21 19 21C18.4477 21 18 20.5523 18 20C18 19.4477 18.4477 19 19 19C19.5523 19 20 19.4477 20 20Z" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/ChartSpline.vue
+++ b/app/components/Lucide/ChartSpline.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const variants = {
   normal: {
     pathLength: 1,
     opacity: 1,
@@ -24,19 +24,11 @@ const circleVariants = {
   animate: {
     pathLength: [0, 1],
     opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    transition: {
+      delay: 0.15,
+      duration: 0.3,
+      opacity: { delay: 0.1 },
+    },
   },
 };
 
@@ -93,32 +85,12 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <path d="M3 3v16a2 2 0 0 0 2 2h16" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M7 16c.5-2 1.5-7 4-7 2 0 2 3 4 3 2.5 0 4.5-5 5-7"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/CircleHelp.vue
+++ b/app/components/Lucide/CircleHelp.vue
@@ -16,28 +16,9 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const variants = {
+  normal: { rotate: 0 },
+  animate: { rotate: [0, -10, 10, -10, 0] },
 };
 
 const isControlled = ref(false);
@@ -93,32 +74,18 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <circle cx="12" cy="12" r="10" />
+      <motion.g
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
+        :transition="{
+          duration: 0.5,
+          ease: 'easeInOut',
+        }"
+      >
+        <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+        <path d="M12 17h.01" />
+      </motion.g>
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/CloudRain.vue
+++ b/app/components/Lucide/CloudRain.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const rainVariants = {
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    transition: {
+      staggerChildren: 0.2,
+    },
   },
 };
 
-const pathVariants = {
+const rainChildVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
-    pathOffset: 0,
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    opacity: [1, 0.2, 1],
+    transition: {
+      duration: 1,
+      repeat: Infinity,
+      ease: 'easeInOut',
+    },
   },
 };
 
@@ -93,32 +91,14 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
+      <!-- Cloud - static -->
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
+      <!-- Rain lines - opacity animation -->
+      <motion.g :variants="rainVariants" :animate="currentState">
+        <motion.path :variants="rainChildVariants" d="M16 14v6" />
+        <motion.path :variants="rainChildVariants" d="M8 14v6" />
+        <motion.path :variants="rainChildVariants" d="M12 16v6" />
+      </motion.g>
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/CloudRainWind.vue
+++ b/app/components/Lucide/CloudRainWind.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const windVariants = {
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    transition: {
+      staggerChildren: 0.2,
+    },
   },
 };
 
-const pathVariants = {
+const windChildVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
-    pathOffset: 0,
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    opacity: [1, 0.2, 1],
+    transition: {
+      duration: 1,
+      repeat: Infinity,
+      ease: 'easeInOut',
+    },
   },
 };
 
@@ -93,32 +91,14 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
+      <!-- Cloud - static -->
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
+      <!-- Wind lines - opacity animation -->
+      <motion.g :variants="windVariants" :animate="currentState">
+        <motion.path :variants="windChildVariants" d="m9.2 22 3-7" />
+        <motion.path :variants="windChildVariants" d="m9 13-3 7" />
+        <motion.path :variants="windChildVariants" d="m17 13-3 7" />
+      </motion.g>
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/CloudSun.vue
+++ b/app/components/Lucide/CloudSun.vue
@@ -16,28 +16,27 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const cloudVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
+    x: 0,
+    y: 0,
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    x: [-1, 1, -1, 1, 0],
+    y: [-1, 1, -1, 1, 0],
+    transition: {
+      duration: 1,
+      ease: 'easeInOut',
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
+const sunVariants = {
+  normal: { opacity: 1 },
+  animate: (i: unknown) => ({
     opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+    transition: { delay: Number(i) * 0.1, duration: 0.3 },
+  }),
 };
 
 const isControlled = ref(false);
@@ -71,6 +70,14 @@ defineExpose({
   startAnimation,
   stopAnimation,
 });
+
+const sunRays = [
+  'M12 2v2',
+  'm4.93 4.93 1.41 1.41',
+  'M20 12h2',
+  'm19.07 4.93-1.41 1.41',
+  'M15.947 12.65a4 4 0 0 0-5.925-4.128',
+];
 </script>
 
 <template>
@@ -92,33 +99,22 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      style="overflow: visible"
     >
+      <motion.g
+        :variants="cloudVariants"
+        :animate="currentState"
+      >
+        <path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z" />
+      </motion.g>
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        v-for="(d, index) in sunRays"
+        :key="d"
+        :d="d"
+        :variants="sunVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :custom="index + 1"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Discord.vue
+++ b/app/components/Lucide/Discord.vue
@@ -16,27 +16,22 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const variants = {
   normal: {
-    pathLength: 1,
+    translateX: 0,
     opacity: 1,
+    transition: {
+      duration: 0.2,
+    },
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
+    translateX: [0, -2, 2, -2, 2, 0],
     opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    transition: {
+      duration: 0.4,
+      times: [0, 0.2, 0.4, 0.6, 0.8, 1],
+      ease: 'easeInOut',
+    },
   },
 };
 
@@ -86,39 +81,39 @@ defineExpose({
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
-      viewBox="0 0 24 24"
+      viewBox="0 0 44 44"
       fill="none"
       stroke="currentColor"
-      stroke-width="2"
+      stroke-width="3"
       stroke-linecap="round"
       stroke-linejoin="round"
+      style="overflow: visible"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M17.54,34.22A47.42,47.42,0,0,1,14.68,38C7.3,37.79,4.5,33,4.5,33A44.83,44.83,0,0,1,9.31,13.48,16.47,16.47,0,0,1,18.69,10l1,2.31"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M17.85,22.67a3.48,3.48,0,0,0-3.37,3.9,3.38,3.38,0,0,0,3.31,3.22,3.53,3.53,0,0,0,3.43-3.9A3.45,3.45,0,0,0,17.85,22.67Z"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        d="M12.2,14.37a28.19,28.19,0,0,1,8.16-2.18A23.26,23.26,0,0,1,24,12a23.26,23.26,0,0,1,3.64.21,28.19,28.19,0,0,1,8.16,2.18m-7.47-2.09l1-2.31a16.47,16.47,0,0,1,9.38,3.51A44.83,44.83,0,0,1,43.5,33S40.7,37.79,33.32,38a47.42,47.42,0,0,1-2.86-3.81"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
+      <motion.path
+        d="M36.92,31.29a29.63,29.63,0,0,1-8.64,3.49,21.25,21.25,0,0,1-4.28.4h0a21.25,21.25,0,0,1-4.28-.4,29.63,29.63,0,0,1-8.64-3.49"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+      />
+      <motion.path
+        d="M30.15,22.67a3.48,3.48,0,0,1,3.37,3.9,3.38,3.38,0,0,1-3.31,3.22,3.53,3.53,0,0,1-3.43-3.9A3.45,3.45,0,0,1,30.15,22.67Z"
+        :variants="variants"
+        :animate="currentState"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Dribbble.vue
+++ b/app/components/Lucide/Dribbble.vue
@@ -18,25 +18,45 @@ const emit = defineEmits<{
 
 const circleVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
 const pathVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
     pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
@@ -93,32 +113,28 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
       <motion.circle
         cx="12"
         cy="12"
         r="10"
         :variants="circleVariants"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+      />
+      <motion.path
+        d="M19.13 5.09C15.22 9.14 10 10.44 2.25 10.94"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M21.75 12.84c-6.62-1.41-12.14 1-16.38 6.32"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M8.56 2.75c4.37 6 6 9.42 8 17.72"
+        :variants="pathVariants"
+        :animate="currentState"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Facebook.vue
+++ b/app/components/Lucide/Facebook.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const facebookVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
     pathLength: 1,
-    opacity: 1,
     pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
@@ -86,7 +84,6 @@ defineExpose({
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
-      viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
       stroke-width="2"
@@ -94,31 +91,10 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"
+        :variants="facebookVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/History.vue
+++ b/app/components/Lucide/History.vue
@@ -16,27 +16,50 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const arrowTransition = {
+  type: 'spring',
+  stiffness: 250,
+  damping: 25,
+};
+
+const arrowVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
+    rotate: '0deg',
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    rotate: '-50deg',
   },
 };
 
-const pathVariants = {
+const handTransition = {
+  duration: 0.6,
+  ease: [0.4, 0, 0.2, 1],
+};
+
+const handVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
+    rotate: 0,
+    originX: '50%',
+    originY: '50%',
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    rotate: -360,
+  },
+};
+
+const minuteHandTransition = {
+  duration: 0.5,
+  ease: 'easeInOut',
+};
+
+const minuteHandVariants = {
+  normal: {
+    rotate: 0,
+    originX: '50%',
+    originY: '50%',
+  },
+  animate: {
+    rotate: -45,
   },
 };
 
@@ -93,32 +116,32 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.g
+        :transition="arrowTransition"
+        :variants="arrowVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+      >
+        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+        <path d="M3 3v5h5" />
+      </motion.g>
+      <motion.line
+        x1="12"
+        y1="12"
+        x2="12"
+        y2="7"
+        :variants="handVariants"
+        :animate="currentState"
+        :transition="handTransition"
       />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+      <motion.line
+        x1="12"
+        y1="12"
+        x2="16"
+        y2="14"
+        :variants="minuteHandVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :transition="minuteHandTransition"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Instagram.vue
+++ b/app/components/Lucide/Instagram.vue
@@ -16,27 +16,69 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const rectVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
 const pathVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
     pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const lineVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
@@ -93,32 +135,29 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.rect
+        x="2"
+        y="2"
+        width="20"
+        height="20"
+        rx="5"
+        ry="5"
+        :variants="rectVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
+        d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+      <motion.line
+        x1="17.5"
+        y1="6.5"
+        x2="17.51"
+        y2="6.5"
+        :variants="lineVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Key.vue
+++ b/app/components/Lucide/Key.vue
@@ -16,27 +16,23 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const svgVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
+    rotate: 0,
+    transition: {
+      type: 'spring',
+      stiffness: 120,
+      damping: 14,
+      duration: 0.8,
+    },
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    rotate: [-3, -33, -25, -28],
+    transition: {
+      duration: 0.6,
+      times: [0, 0.6, 0.8, 1],
+      ease: 'easeInOut',
+    },
   },
 };
 
@@ -82,7 +78,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +88,13 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :animate="currentState"
+      :variants="svgVariants"
+      style="transform-origin: 30% 70%;"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
+      <path d="m21 2-9.6 9.6" />
+      <circle cx="7.5" cy="15.5" r="5.5" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/KeyCircle.vue
+++ b/app/components/Lucide/KeyCircle.vue
@@ -16,27 +16,15 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const svgVariants = {
+  normal: { y: 0, rotate: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    y: [0, -3, 0, -2, 0],
+    rotate: [0, 3, -3, 0],
+    transition: {
+      duration: 0.9,
+      bounce: 0.5,
+    }
   },
 };
 
@@ -82,7 +70,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +80,11 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :animate="currentState"
+      :variants="svgVariants"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M2.586 17.414A2 2 0 0 0 2 18.828V21a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h.172a2 2 0 0 0 1.414-.586l.814-.814a6.5 6.5 0 1 0-4-4z" />
+      <circle cx="16.5" cy="7.5" r=".5" fill="currentColor" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/KeySquare.vue
+++ b/app/components/Lucide/KeySquare.vue
@@ -16,27 +16,15 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const svgVariants = {
+  normal: { rotate: 0, scale: 1 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    rotate: [0, 15, -15, 0],
+    scale: [1, 1.05, 1, 1],
+    transition: {
+      duration: 0.6,
+      bounce: 0.4,
+    }
   },
 };
 
@@ -82,7 +70,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +80,12 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :animate="currentState"
+      :variants="svgVariants"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M12.4 2.7a2.5 2.5 0 0 1 3.4 0l5.5 5.5a2.5 2.5 0 0 1 0 3.4l-3.7 3.7a2.5 2.5 0 0 1-3.4 0L8.7 9.8a2.5 2.5 0 0 1 0-3.4z" />
+      <path d="m14 7 3 3" />
+      <path d="m9.4 10.6-6.814 6.814A2 2 0 0 0 2 18.828V21a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h.172a2 2 0 0 0 1.414-.586l.814-.814" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Linkedin.vue
+++ b/app/components/Lucide/Linkedin.vue
@@ -16,27 +16,69 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const pathVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
-const pathVariants = {
+const rectVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
     pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const circleVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
@@ -86,39 +128,33 @@ defineExpose({
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
-      viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      viewBox="0 0 24 24"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+      <motion.rect
+        x="2"
+        y="9"
+        width="4"
+        height="12"
+        :variants="rectVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
+        cx="4"
+        cy="4"
+        r="2"
         :variants="circleVariants"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Logout.vue
+++ b/app/components/Lucide/Logout.vue
@@ -16,27 +16,14 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { x: 0, translateX: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    x: 2,
+    translateX: [0, -3, 0],
+    transition: {
+      duration: 0.4,
+    },
   },
 };
 
@@ -93,32 +80,20 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <motion.polyline
+        points="16 17 21 12 16 7"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
+      <motion.line
+        x1="21"
+        x2="9"
+        y1="12"
+        y2="12"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/MoonAlt.vue
+++ b/app/components/Lucide/MoonAlt.vue
@@ -16,27 +16,16 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const svgVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
+    rotate: 0,
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    rotate: [0, -10, 10, -5, 5, 0],
+    transition: {
+      duration: 1.2,
+      ease: 'easeInOut',
+    },
   },
 };
 
@@ -82,7 +71,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +81,10 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :variants="svgVariants"
+      :animate="currentState"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Redo.vue
+++ b/app/components/Lucide/Redo.vue
@@ -16,28 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+// Custom easing function similar to cubicBezier in Framer Motion
+const customEasing = [0.25, 0.1, 0.25, 1];
+
+const firstPathVariants = {
+  normal: { translateX: 0, translateY: 0, rotate: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+    translateX: [0, -2.1, 0],
+    translateY: [0, -1.4, 0],
+    rotate: [0, -12, 0],
+    transition: { duration: 0.6, ease: customEasing }
+  }
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const secondPathVariants = {
+  normal: { pathLength: 1 },
+  animate: { 
+    pathLength: [1, 0.8, 1],
+    transition: { duration: 0.6, ease: customEasing }
+  }
 };
 
 const isControlled = ref(false);
@@ -94,31 +91,15 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M21 7v6h-6"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :variants="firstPathVariants"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3l3 2.7"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :variants="secondPathVariants"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/RedoDot.vue
+++ b/app/components/Lucide/RedoDot.vue
@@ -16,28 +16,33 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+// Custom easing function similar to cubicBezier in Framer Motion
+const customEasing = [0.25, 0.1, 0.25, 1];
+
+const firstPathVariants = {
+  normal: { translateX: 0, translateY: 0, rotate: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+    translateX: [0, -2.1, 0],
+    translateY: [0, -1.4, 0],
+    rotate: [0, -12, 0],
+    transition: { duration: 0.6, ease: customEasing }
+  }
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const secondPathVariants = {
+  normal: { pathLength: 1 },
+  animate: { 
+    pathLength: [1, 0.8, 1],
+    transition: { duration: 0.6, ease: customEasing }
+  }
+};
+
+const circleVariants = {
+  normal: { scale: 1 },
+  animate: { 
+    scale: [1, 1.2, 1],
+    transition: { duration: 0.6, ease: customEasing }
+  }
 };
 
 const isControlled = ref(false);
@@ -94,31 +99,22 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M21 7v6h-6"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :variants="firstPathVariants"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3l3 2.7"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :variants="secondPathVariants"
       />
       <motion.circle
         cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
+        cy="17"
+        r="1"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :variants="circleVariants"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/RefreshCCWDot.vue
+++ b/app/components/Lucide/RefreshCCWDot.vue
@@ -16,28 +16,10 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const groupVariants = {
+  normal: { rotate: '0deg' },
+  animate: { rotate: '-50deg' },
+  transition: { type: 'spring', stiffness: 250, damping: 25 }
 };
 
 const isControlled = ref(false);
@@ -93,32 +75,16 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.g
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
+        :variants="groupVariants"
+      >
+        <path d="M3 2v6h6" />
+        <path d="M21 12A9 9 0 0 0 6 5.3L3 8" />
+        <path d="M21 22v-6h-6" />
+        <path d="M3 12a9 9 0 0 0 15 6.7l3-2.7" />
+      </motion.g>
+      <circle cx="12" cy="12" r="1" />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/RefreshCW.vue
+++ b/app/components/Lucide/RefreshCW.vue
@@ -16,28 +16,10 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const svgVariants = {
+  normal: { rotate: '0deg' },
+  animate: { rotate: '50deg' },
+  transition: { type: 'spring', stiffness: 250, damping: 25 }
 };
 
 const isControlled = ref(false);
@@ -82,7 +64,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +74,13 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :animate="currentState"
+      :variants="svgVariants"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+      <path d="M8 16H3v5" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/RefreshCWOff.vue
+++ b/app/components/Lucide/RefreshCWOff.vue
@@ -16,28 +16,13 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const svgVariants = {
+  normal: { x: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    x: [-3, 3, -3, 3, 0],
+    transition: { duration: 0.4 },
   },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+  transition: { type: 'spring', stiffness: 500, damping: 20 }
 };
 
 const isControlled = ref(false);
@@ -82,7 +67,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +77,16 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :animate="currentState"
+      :variants="svgVariants"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M21 8L18.74 5.74A9.75 9.75 0 0 0 12 3C11 3 10.03 3.16 9.13 3.47" />
+      <path d="M8 16H3v5" />
+      <path d="M3 12C3 9.51 4 7.26 5.64 5.64" />
+      <path d="m3 16 2.26 2.26A9.75 9.75 0 0 0 12 21c2.49 0 4.74-1 6.36-2.64" />
+      <path d="M21 12c0 1-.16 1.97-.47 2.87" />
+      <path d="M21 3v5h-5" />
+      <path d="M22 22 2 2" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/RotateCCW.vue
+++ b/app/components/Lucide/RotateCCW.vue
@@ -16,28 +16,10 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const svgVariants = {
+  normal: { rotate: '0deg' },
+  animate: { rotate: '-50deg' },
+  transition: { type: 'spring', stiffness: 250, damping: 25 }
 };
 
 const isControlled = ref(false);
@@ -82,7 +64,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +74,11 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :animate="currentState"
+      :variants="svgVariants"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+      <path d="M3 3v5h5" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/RotateCW.vue
+++ b/app/components/Lucide/RotateCW.vue
@@ -16,28 +16,10 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const svgVariants = {
+  normal: { rotate: '0deg' },
+  animate: { rotate: '50deg' },
+  transition: { type: 'spring', stiffness: 250, damping: 25 }
 };
 
 const isControlled = ref(false);
@@ -82,7 +64,7 @@ defineExpose({
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
   >
-    <svg
+    <motion.svg
       xmlns="http://www.w3.org/2000/svg"
       :width="size"
       :height="size"
@@ -92,33 +74,11 @@ defineExpose({
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :animate="currentState"
+      :variants="svgVariants"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
-    </svg>
+      <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+      <path d="M21 3v5h-5" />
+    </motion.svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/SquareArrowDown.vue
+++ b/app/components/Lucide/SquareArrowDown.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+const squareVariants = {
+  normal: { transition: { duration: 0.4 } },
+  animate: { transition: { duration: 0.6, ease: 'easeInOut' } },
 };
 
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'm8 12 4 4 4-4', translateY: 0, opacity: 1 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: 'm8 12 4 4 4-4',
+    translateY: [0, -3, 0],
+    transition: { duration: 0.4 },
+  },
+};
+
+const secondPathVariants = {
+  normal: { d: 'M12 8v8', opacity: 1 },
+  animate: {
+    d: ['M12 8v8', 'M12 8v5', 'M12 8v8'],
+    transition: { duration: 0.4 },
   },
 };
 
@@ -93,32 +91,25 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.rect
+        width="18"
+        height="18"
+        x="3"
+        y="3"
+        rx="2"
+        :variants="squareVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        d="m8 12 4 4 4-4"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        :variants="secondPathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        d="M12 8v8"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/SquareArrowLeft.vue
+++ b/app/components/Lucide/SquareArrowLeft.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+const squareVariants = {
+  normal: { transition: { duration: 0.4 } },
+  animate: { transition: { duration: 0.6, ease: 'easeInOut' } },
 };
 
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'm12 8-4 4 4 4', translateX: 0, opacity: 1 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: 'm12 8-4 4 4 4',
+    translateX: [0, 3, 0],
+    transition: { duration: 0.4 },
+  },
+};
+
+const secondPathVariants = {
+  normal: { d: 'M16 12H8', opacity: 1 },
+  animate: {
+    d: ['M16 12H8', 'M16 12H13', 'M16 12H8'],
+    transition: { duration: 0.4 },
   },
 };
 
@@ -93,32 +91,25 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.rect
+        width="18"
+        height="18"
+        x="3"
+        y="3"
+        rx="2"
+        :variants="squareVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        d="m12 8-4 4 4 4"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        :variants="secondPathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        d="M16 12H8"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/SquareArrowRight.vue
+++ b/app/components/Lucide/SquareArrowRight.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+const squareVariants = {
+  normal: { transition: { duration: 0.4 } },
+  animate: { transition: { duration: 0.6, ease: 'easeInOut' } },
 };
 
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'M8 12h8', opacity: 1 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: ['M8 12h8', 'M8 12h5', 'M8 12h8'],
+    transition: { duration: 0.4 },
+  },
+};
+
+const secondPathVariants = {
+  normal: { d: 'm12 8 4 4-4 4', translateX: 0, opacity: 1 },
+  animate: {
+    d: 'm12 8 4 4-4 4',
+    translateX: [0, -3, 0],
+    transition: { duration: 0.4 },
   },
 };
 
@@ -93,32 +91,25 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.rect
+        width="18"
+        height="18"
+        x="3"
+        y="3"
+        rx="2"
+        :variants="squareVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        d="M8 12h8"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        :variants="secondPathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        d="m12 8 4 4-4 4"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/SquareArrowUp.vue
+++ b/app/components/Lucide/SquareArrowUp.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+const squareVariants = {
+  normal: { transition: { duration: 0.4 } },
+  animate: { transition: { duration: 0.6, ease: 'easeInOut' } },
 };
 
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
+  normal: { d: 'm16 12-4-4-4 4', translateY: 0, opacity: 1 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    d: 'm16 12-4-4-4 4',
+    translateY: [0, 3, 0],
+    transition: { duration: 0.4 },
+  },
+};
+
+const secondPathVariants = {
+  normal: { d: 'M12 16V8', opacity: 1 },
+  animate: {
+    d: ['M12 16V8', 'M12 16V13', 'M12 16V8'],
+    transition: { duration: 0.4 },
   },
 };
 
@@ -93,32 +91,25 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.rect
+        width="18"
+        height="18"
+        x="3"
+        y="3"
+        rx="2"
+        :variants="squareVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        d="m16 12-4-4-4 4"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        :variants="secondPathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        d="M12 16V8"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Stethoscope.vue
+++ b/app/components/Lucide/Stethoscope.vue
@@ -16,27 +16,31 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+const DURATION = 0.25;
+
+const calculateDelay = (i: unknown) => {
+  return Number(i) === 0 ? 0.1 : Number(i) * DURATION + 0.1;
 };
 
 const pathVariants = {
   normal: {
     pathLength: 1,
-    opacity: 1,
     pathOffset: 0,
+    opacity: 1,
+    transition: { delay: 0 },
   },
+  animate: {
+    pathOffset: [1, 0],
+    pathLength: [0, 1],
+    opacity: [0, 1],
+  },
+};
+
+const circleVariants = {
+  normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
   animate: {
     pathLength: [0, 1],
     opacity: [0, 1],
-    pathOffset: [1, 0],
   },
 };
 
@@ -94,31 +98,57 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M11 2v2"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :transition="{
+          duration: DURATION,
+          delay: calculateDelay(2),
+          opacity: { delay: calculateDelay(2) },
+        }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
+        d="M5 2v2"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :transition="{
+          duration: DURATION,
+          delay: calculateDelay(2),
+          opacity: { delay: calculateDelay(2) },
+        }"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
+        d="M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :transition="{
+          duration: DURATION,
+          delay: calculateDelay(2),
+          opacity: { delay: calculateDelay(2) },
+        }"
+      />
+      <motion.path
+        d="M8 15a6 6 0 0 0 12 0v-3"
+        :variants="pathVariants"
+        :animate="currentState"
+        :transition="{
+          duration: DURATION,
+          delay: calculateDelay(1),
+          opacity: { delay: calculateDelay(1) },
+        }"
       />
       <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
+        cx="20"
+        cy="10"
+        r="2"
         :variants="circleVariants"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :transition="{
+          duration: DURATION,
+          delay: calculateDelay(0),
+          opacity: { delay: calculateDelay(0) },
+        }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/SunDim.vue
+++ b/app/components/Lucide/SunDim.vue
@@ -16,28 +16,12 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
+  normal: { opacity: 1 },
+  animate: (i: unknown) => ({
     opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+    transition: { delay: Number(i) * 0.1, duration: 0.3 },
+  }),
 };
 
 const isControlled = ref(false);
@@ -71,6 +55,17 @@ defineExpose({
   startAnimation,
   stopAnimation,
 });
+
+const rays = [
+  'M12 4h.01',
+  'M20 12h.01',
+  'M12 20h.01',
+  'M4 12h.01',
+  'M17.657 6.343h.01',
+  'M17.657 17.657h.01',
+  'M6.343 17.657h.01',
+  'M6.343 6.343h.01',
+];
 </script>
 
 <template>
@@ -93,32 +88,15 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <circle cx="12" cy="12" r="4" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        v-for="(d, index) in rays"
+        :key="d"
+        :d="d"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :custom="index + 1"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/SunMedium.vue
+++ b/app/components/Lucide/SunMedium.vue
@@ -16,28 +16,12 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
+  normal: { opacity: 1 },
+  animate: (i: unknown) => ({
     opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+    transition: { delay: Number(i) * 0.1, duration: 0.3 },
+  }),
 };
 
 const isControlled = ref(false);
@@ -71,6 +55,17 @@ defineExpose({
   startAnimation,
   stopAnimation,
 });
+
+const rays = [
+  'M12 3v1',
+  'M12 20v1',
+  'M3 12h1',
+  'M20 12h1',
+  'm18.364 5.636-.707.707',
+  'm6.343 17.657-.707.707',
+  'm5.636 5.636.707.707',
+  'm17.657 17.657.707.707',
+];
 </script>
 
 <template>
@@ -93,32 +88,15 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <circle cx="12" cy="12" r="4" />
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        v-for="(d, index) in rays"
+        :key="d"
+        :d="d"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :custom="index + 1"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/SunMoon.vue
+++ b/app/components/Lucide/SunMoon.vue
@@ -16,28 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const sunVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
+    rotate: 0,
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    rotate: [0, -5, 5, -2, 2, 0],
+    transition: {
+      duration: 1.5,
+      ease: 'easeInOut',
+    },
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
+const moonVariants = {
+  normal: { opacity: 1 },
+  animate: (i: unknown) => ({
     opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+    transition: { delay: Number(i) * 0.1, duration: 0.3 },
+  }),
 };
 
 const isControlled = ref(false);
@@ -71,6 +68,17 @@ defineExpose({
   startAnimation,
   stopAnimation,
 });
+
+const rays = [
+  'M12 2v2',
+  'M12 20v2',
+  'm4.9 4.9 1.4 1.4',
+  'm17.7 17.7 1.4 1.4',
+  'M2 12h2',
+  'M20 12h2',
+  'm6.3 17.7-1.4 1.4',
+  'm19.1 4.9-1.4 1.4',
+];
 </script>
 
 <template>
@@ -93,32 +101,20 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <motion.g
+        :variants="sunVariants"
+        :animate="currentState"
+      >
+        <path d="M12 8a2.83 2.83 0 0 0 4 4 4 4 0 1 1-4-4" />
+      </motion.g>
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        v-for="(d, index) in rays"
+        :key="d"
+        :d="d"
+        :variants="moonVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :custom="index + 1"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Sunset.vue
+++ b/app/components/Lucide/Sunset.vue
@@ -16,28 +16,21 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const arrowVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
+    y: 0,
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
+    y: [0, 1, 0],
   },
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
+const raysVariants = {
+  normal: { opacity: 1 },
+  animate: (i: unknown) => ({
     opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+    transition: { delay: Number(i) * 0.1, duration: 0.3 },
+  }),
 };
 
 const isControlled = ref(false);
@@ -71,6 +64,14 @@ defineExpose({
   startAnimation,
   stopAnimation,
 });
+
+const rays = [
+  'm4.93 10.93 1.41 1.41',
+  'M2 18h2',
+  'M20 18h2',
+  'm19.07 10.93-1.41 1.41',
+  'M22 22H2',
+];
 </script>
 
 <template>
@@ -93,32 +94,23 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <motion.g
+        :variants="arrowVariants"
+        :animate="currentState"
+      >
+        <path d="M12 10V2" />
+        <path d="m16 6-4 4-4-4" />
+      </motion.g>
+
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        v-for="(d, index) in rays"
+        :key="d"
+        :d="d"
+        :variants="raysVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="index + 1"
       />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
+      <path d="M16 18a4 4 0 0 0-8 0" />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Tornado.vue
+++ b/app/components/Lucide/Tornado.vue
@@ -16,28 +16,28 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
   normal: {
-    pathLength: 1,
+    x: 0,
     opacity: 1,
-    pathOffset: 0,
+    transition: {
+      duration: 0.3,
+      ease: 'easeInOut',
+    },
   },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+  animate: (custom: unknown) => ({
+    x: [0, (custom as number) * 1, 0],
+    opacity: 1,
+    transition: {
+      x: {
+        duration: 0.6,
+        repeat: 0.7,
+        repeatType: 'reverse',
+        ease: 'easeInOut',
+        delay: (custom as number) * 0.1,
+      },
+    },
+  }),
 };
 
 const isControlled = ref(false);
@@ -94,31 +94,35 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M21 4H3"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="1"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
+        d="M18 8H6"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="2"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
+        d="M19 12H9"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="3"
       />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
+      <motion.path
+        d="M16 16h-6"
+        :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :custom="4"
+      />
+      <motion.path
+        d="M11 20H9"
+        :variants="pathVariants"
+        :animate="currentState"
+        :custom="5"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Twitch.vue
+++ b/app/components/Lucide/Twitch.vue
@@ -16,27 +16,47 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const pathVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
-const pathVariants = {
+const lineVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
     pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
@@ -94,31 +114,20 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M21 2H3v16h5v4l4-4h5l4-4V2z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M11 11V7"
+        :variants="lineVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        d="M16 11V7"
+        :variants="lineVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Twitter.vue
+++ b/app/components/Lucide/Twitter.vue
@@ -16,27 +16,25 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
 const pathVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
     pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
@@ -94,31 +92,10 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/UndoDot.vue
+++ b/app/components/Lucide/UndoDot.vue
@@ -16,28 +16,33 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+// Custom easing function similar to cubicBezier in Framer Motion
+const customEasing = [0.25, 0.1, 0.25, 1];
+
+const firstPathVariants = {
+  normal: { translateX: 0, translateY: 0, rotate: 0 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
+    translateX: [0, 2.1, 0],
+    translateY: [0, -1.4, 0],
+    rotate: [0, 12, 0],
+    transition: { duration: 0.6, ease: customEasing }
+  }
 };
 
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+const secondPathVariants = {
+  normal: { pathLength: 1 },
+  animate: { 
+    pathLength: [1, 0.8, 1],
+    transition: { duration: 0.6, ease: customEasing }
+  }
+};
+
+const circleVariants = {
+  normal: { scale: 1 },
+  animate: { 
+    scale: [1, 1.2, 1],
+    transition: { duration: 0.6, ease: customEasing }
+  }
 };
 
 const isControlled = ref(false);
@@ -94,31 +99,22 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M3 7v6h6"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :variants="firstPathVariants"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M21 17a9 9 0 0 0-15-6.7L3 13"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :variants="secondPathVariants"
       />
       <motion.circle
         cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
+        cy="17"
+        r="1"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :variants="circleVariants"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Vibrate.vue
+++ b/app/components/Lucide/Vibrate.vue
@@ -16,27 +16,16 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const rectVariants = {
   normal: {
-    pathLength: 1,
-    opacity: 1,
+    rotate: 0,
   },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    rotate: [0, -5, 5, -5, 5, 0],
+    transition: {
+      duration: 0.4,
+      times: [0, 0.2, 0.4, 0.6, 0.8, 1],
+    },
   },
 };
 
@@ -93,32 +82,18 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <path d="m2 8 2 2-2 2 2 2-2 2" />
+      <path d="m22 8-2 2 2 2-2 2 2 2" />
+      <motion.rect
+        width="8"
+        height="14"
+        x="8"
+        y="5"
+        rx="1"
+        :variants="rectVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        style="transform-origin: center"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Waves.vue
+++ b/app/components/Lucide/Waves.vue
@@ -16,6 +16,14 @@ const emit = defineEmits<{
   stopAnimation: []
 }>()
 
+const pathVariants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: 'linear' }
+  }
+}
+
 const isControlled = ref(false)
 const currentState = ref('normal')
 
@@ -71,38 +79,17 @@ defineExpose({
     >
       <motion.path
         d="M2 6c.6.5 1.2 1 2.5 1C7 7 7 5 9.5 5c2.6 0 2.4 2 5 2c2.5 0 2.5-2 5-2c1.3 0 1.9.5 2.5 1"
-        :initial="{ pathLength: 1 }"
-        :variants="{
-          normal: { pathLength: 1 },
-          animate: {
-            pathLength: [0, 1],
-            transition: { duration: 0.4, ease: 'linear' }
-          }
-        }"
+        :variants="pathVariants"
         :animate="currentState"
       />
       <motion.path
         d="M2 12c.6.5 1.2 1 2.5 1c2.5 0 2.5-2 5-2c2.6 0 2.4 2 5 2c2.5 0 2.5-2 5-2c1.3 0 1.9.5 2.5 1"
-        :initial="{ pathLength: 1 }"
-        :variants="{
-          normal: { pathLength: 1 },
-          animate: {
-            pathLength: [0, 1],
-            transition: { duration: 0.4, ease: 'linear' }
-          }
-        }"
+        :variants="pathVariants"
         :animate="currentState"
       />
       <motion.path
         d="M2 18c.6.5 1.2 1 2.5 1c2.5 0 2.5-2 5-2c2.6 0 2.4 2 5 2c2.5 0 2.5-2 5-2c1.3 0 1.9.5 2.5 1"
-        :initial="{ pathLength: 1 }"
-        :variants="{
-          normal: { pathLength: 1 },
-          animate: {
-            pathLength: [0, 1],
-            transition: { duration: 0.4, ease: 'linear' }
-          }
-        }"
+        :variants="pathVariants"
         :animate="currentState"
       />
     </svg>

--- a/app/components/Lucide/WavesLadder.vue
+++ b/app/components/Lucide/WavesLadder.vue
@@ -16,27 +16,16 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
+const gVariants = {
+  normal: { y: 0, opacity: 1 },
   animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
+    y: [13, 0],
+    opacity: [0, 0, 1],
+    transition: { 
+      duration: 1, 
+      times: [0, 0.5, 1], 
+      repeat: 0 
+    },
   },
 };
 
@@ -93,32 +82,16 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <path d="M2 18c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
+      <motion.g
+        :variants="gVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
-      />
+      >
+        <path d="M19 5a2 2 0 0 0-2 2v11" />
+        <path d="M7 13h10" />
+        <path d="M7 9h10" />
+        <path d="M9 5a2 2 0 0 0-2 2v11" />
+      </motion.g>
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/WindArrowDown.vue
+++ b/app/components/Lucide/WindArrowDown.vue
@@ -16,27 +16,46 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
+const windVariants = {
+  normal: (custom: unknown) => ({
     pathLength: 1,
     opacity: 1,
     pathOffset: 0,
-  },
-  animate: {
+    transition: {
+      duration: 0.3,
+      ease: 'easeInOut',
+      delay: custom as number,
+    },
+  }),
+  animate: (custom: unknown) => ({
     pathLength: [0, 1],
     opacity: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.5,
+      ease: 'easeInOut',
+      delay: custom as number,
+    },
+  }),
+};
+
+const arrowVariants = {
+  normal: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      duration: 0.3,
+      ease: 'easeInOut',
+    },
+  },
+  animate: {
+    y: [-10, 0],
+    opacity: [0, 1],
+    transition: {
+      duration: 0.5,
+      ease: 'easeInOut',
+      delay: 0.35,
+    },
   },
 };
 
@@ -93,32 +112,29 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
+      <!-- Wind paths -->
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+        d="M12.8 21.6A2 2 0 1 0 14 18H2"
+        :variants="windVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="0.2"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M17.5 10a2.5 2.5 0 1 1 2 4H2"
+        :variants="windVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="0.4"
       />
       <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+        d="M10 2v8"
+        :variants="arrowVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
+      <motion.path
+        d="m6 6 4 4 4-4"
+        :variants="arrowVariants"
         :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Workflow.vue
+++ b/app/components/Lucide/Workflow.vue
@@ -16,28 +16,20 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const variants = {
   normal: {
     pathLength: 1,
     opacity: 1,
   },
-  animate: {
+  animate: (custom: unknown) => ({
     pathLength: [0, 1],
     opacity: [0, 1],
-  },
-};
-
-const pathVariants = {
-  normal: {
-    pathLength: 1,
-    opacity: 1,
-    pathOffset: 0,
-  },
-  animate: {
-    pathLength: [0, 1],
-    opacity: [0, 1],
-    pathOffset: [1, 0],
-  },
+    transition: {
+      duration: 0.3,
+      opacity: { delay: 0.15 },
+      delay: Number(custom) * 0.1,
+    },
+  }),
 };
 
 const isControlled = ref(false);
@@ -93,32 +85,32 @@ defineExpose({
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
-        :variants="pathVariants"
+      <motion.rect
+        width="8"
+        height="8"
+        x="3"
+        y="3"
+        rx="2"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="0"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M7 11v4a2 2 0 0 0 2 2h4"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
+        :custom="3"
       />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
+      <motion.rect
+        width="8"
+        height="8"
+        x="13"
+        y="13"
+        rx="2"
+        :variants="variants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
+        :custom="0"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/components/Lucide/Youtube.vue
+++ b/app/components/Lucide/Youtube.vue
@@ -16,27 +16,47 @@ const emit = defineEmits<{
   stopAnimation: [];
 }>();
 
-const circleVariants = {
+const pathVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
-const pathVariants = {
+const triangleVariants = {
   normal: {
-    pathLength: 1,
     opacity: 1,
+    pathLength: 1,
     pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
   },
   animate: {
-    pathLength: [0, 1],
     opacity: [0, 1],
+    pathLength: [0, 1],
     pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: 'linear',
+      opacity: { duration: 0.1 },
+    },
   },
 };
 
@@ -94,31 +114,15 @@ defineExpose({
       stroke-linejoin="round"
     >
       <motion.path
-        d="M21.54 15H17a2 2 0 0 0-2 2v4.54"
+        d="M2.5 17a24.12 24.12 0 0 1 0-10 2 2 0 0 1 1.4-1.4 49.56 49.56 0 0 1 16.2 0A2 2 0 0 1 21.5 7a24.12 24.12 0 0 1 0 10 2 2 0 0 1-1.4 1.4 49.55 49.55 0 0 1-16.2 0A2 2 0 0 1 2.5 17"
         :variants="pathVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
       />
       <motion.path
-        d="M7 3.34V5a3 3 0 0 0 3 3a2 2 0 0 1 2 2c0 1.1.9 2 2 2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h3.17"
-        :variants="pathVariants"
+        d="M10 15l5-3-5-3z"
+        :variants="triangleVariants"
         :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.path
-        d="M11 21.95V18a2 2 0 0 0-2-2a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05"
-        :variants="pathVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.7, delay: 0.5, opacity: { delay: 0.5 } }"
-      />
-      <motion.circle
-        cx="12"
-        cy="12"
-        r="10"
-        :variants="circleVariants"
-        :animate="currentState"
-        :transition="{ duration: 0.3, delay: 0.1, opacity: { delay: 0.15 } }"
       />
     </svg>
   </div>
-</template>
+</template> 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -50,6 +50,51 @@
       </AnimatedIconButton>
       <AnimatedIconButton>
         <template #default="{ ref, controlled }">
+          <LucideSquareArrowDown
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSquareArrowUp
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideHistory
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSquareArrowLeft
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSquareArrowRight
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
           <LucideEarth
             :ref="ref"
             :controlled="controlled"
@@ -249,6 +294,456 @@
       <AnimatedIconButton>
         <template #default="{ ref, controlled }">
           <LucideBell
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideKey
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideKeySquare
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideKeyCircle
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideRotateCW
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideRotateCCW
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideRefreshCWOff
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideRefreshCW
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideRefreshCCWDot
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideRedo
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideUndoDot
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideRedoDot
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigDown
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigLeft
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigRight
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigUp
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideAArrowUp
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideChartSpline
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowUp
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowDown
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideVibrate
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideWavesLadder
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideWindArrowDown
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideAirVent
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideTornado
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCloudRain
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCloudRainWind
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigDownDash
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigLeftDash
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigRightDash
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideArrowBigUpDash
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideMoonAlt
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideFacebook
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideTwitter
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideLinkedin
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideYoutube
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideInstagram
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideTwitch
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideDribbble
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideDiscord
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCloudSun
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSunset
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSunDim
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSunMedium
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSunMoon
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCart
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideStethoscope
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideEarth
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideWorkflow
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideLogout
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCircleHelp
             :ref="ref"
             :controlled="controlled"
             :class="primaryColor"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -24,6 +24,11 @@
             href="https://x.com/fayazara"
             class="text-primary-500 hover:underline"
             >Fayaz</a
+          >. and
+          <a
+            href="https://x.com/Joe_Elia"
+            class="text-primary-500 hover:underline"
+            >Joe Elia</a
           >. Work in progress, feel free to contribute on GitHub.
         </p>
       </div>


### PR DESCRIPTION
### ✨ Added new icons

This PR adds the following icons to the repo:

1. `history`  
2. `square-arrow-down`  
3. `square-arrow-left`  
4. `square-arrow-right`  
5. `square-arrow-up`  
6. `key`  
7. `key-square`  
8. `key-circle`  
9. `rotate-cw`  
10. `rotate-ccw`  
11. `refresh-cw-off`  
12. `refresh-cw`  
13. `refresh-ccw-dot`  
14. `redoundo-dot`  
15. `redo-dot`  
16. `arrow-big-down`  
17. `arrow-big-left`  
18. `arrow-big-right`  
19. `arrow-big-up`  
20. `a-arrow-up`  
21. `chart-spline`  
22. `arrow-up`  
23. `arrow-down`  
24. `vibrate`  
25. `waves-ladder`  
26. `waves` (refactored existing code)  
27. `wind-arrow-down`  
28. `air-vent`  
29. `tornado`  
30. `cloud-rain`  
31. `cloud-rain-wind`  
32. `arrow-big-down-dash`  
33. `arrow-big-left-dash`  
34. `arrow-big-right-dash`  
35. `arrow-big-up-dash`  
36. `moon`  
37. `facebook`  
38. `twitter`  
39. `linkedin`  
40. `youtube`  
41. `instagram`  
42. `twitch`  
43. `dribbble`  
44. `discord`  
45. `cloud-sun`  
46. `sunset`  
47. `sun-dim`  
48. `sun-medium`  
49. `sun-moon`  
50. `cart`  
51. `stethoscope`  
52. `earth`  
53. `workflow`  
54. `logout`  
55. `circle-help`  
