### PR TITLE
feat: add 25 icons

### DIFF
--- a/app/components/Lucide/Check.vue
+++ b/app/components/Lucide/Check.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    scale: 1,
+    transition: {
+      duration: 0.3,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    scale: [0.5, 1],
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="M4 12 9 17L20 6"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/ChevronDown.vue
+++ b/app/components/Lucide/ChevronDown.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const defaultTransition = {
+  times: [0, 0.4, 1],
+  duration: 0.5,
+};
+
+const pathVariants = {
+  normal: { y: 0 },
+  animate: { y: [0, 2, 0] },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        :variants="pathVariants"
+        :transition="defaultTransition"
+        :animate="currentState"
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Compass.vue
+++ b/app/components/Lucide/Compass.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const polygonVariants = {
+  normal: {
+    rotate: 0,
+  },
+  animate: {
+    rotate: 360,
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <motion.polygon
+        points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"
+        :variants="polygonVariants"
+        :animate="currentState"
+        :transition="{
+          type: 'spring',
+          stiffness: 120,
+          damping: 15,
+        }"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Copy.vue
+++ b/app/components/Lucide/Copy.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const defaultTransition = {
+  type: 'spring',
+  stiffness: 160,
+  damping: 17,
+  mass: 1,
+};
+
+const rectVariants = {
+  normal: { translateY: 0, translateX: 0 },
+  animate: { translateY: -3, translateX: -3 },
+};
+
+const pathVariants = {
+  normal: { x: 0, y: 0 },
+  animate: { x: 3, y: 3 },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.rect
+        width="14"
+        height="14"
+        x="8"
+        y="8"
+        rx="2"
+        ry="2"
+        :variants="rectVariants"
+        :animate="currentState"
+        :transition="defaultTransition"
+      />
+      <motion.path
+        d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+        :variants="pathVariants"
+        :transition="defaultTransition"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Expand.vue
+++ b/app/components/Lucide/Expand.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const defaultTransition = {
+  type: 'spring',
+  stiffness: 250,
+  damping: 25,
+};
+
+const topRightVariants = {
+  normal: { translateX: '0%', translateY: '0%' },
+  animate: { translateX: '2px', translateY: '2px' },
+};
+
+const bottomLeftVariants = {
+  normal: { translateX: '0%', translateY: '0%' },
+  animate: { translateX: '-2px', translateY: '2px' },
+};
+
+const topLeftVariants = {
+  normal: { translateX: '0%', translateY: '0%' },
+  animate: { translateX: '2px', translateY: '-2px' },
+};
+
+const bottomRightVariants = {
+  normal: { translateX: '0%', translateY: '0%' },
+  animate: { translateX: '-2px', translateY: '-2px' },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="m21 21-6-6m6 6v-4.8m0 4.8h-4.8"
+        :transition="defaultTransition"
+        :variants="topRightVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M3 16.2V21m0 0h4.8M3 21l6-6"
+        :transition="defaultTransition"
+        :variants="bottomLeftVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M21 7.8V3m0 0h-4.8M21 3l-6 6"
+        :transition="defaultTransition"
+        :variants="topLeftVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M3 7.8V3m0 0h4.8M3 3l6 6"
+        :transition="defaultTransition"
+        :variants="bottomRightVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/EyeOff.vue
+++ b/app/components/Lucide/EyeOff.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: { pathLength: 1, opacity: 1, pathOffset: 0 },
+  animate: {
+    pathLength: [0, 2],
+    opacity: [0, 1],
+    pathOffset: [0, 2],
+    transition: { duration: 0.6 },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
+      <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+      <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
+      <motion.path
+        :variants="pathVariants"
+        d="m2 2 20 20"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Fingerprint.vue
+++ b/app/components/Lucide/Fingerprint.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: { pathLength: 1, opacity: 1 },
+  animate: {
+    opacity: [0, 0, 1, 1, 1],
+    pathLength: [0.1, 0.3, 0.5, 0.7, 0.9, 1],
+    transition: {
+      opacity: { duration: 0.5 },
+      pathLength: {
+        duration: 2,
+      },
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path
+        d="M12 10a2 2 0 0 0-2 2c0 1.02-.1 2.51-.26 4"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M12 10a2 2 0 0 0-2 2c0 1.02-.1 2.51-.26 4"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path
+        d="M14 13.12c0 2.38 0 6.38-1 8.88"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M14 13.12c0 2.38 0 6.38-1 8.88"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path
+        d="M17.29 21.02c.12-.6.43-2.3.5-3.02"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M17.29 21.02c.12-.6.43-2.3.5-3.02"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path
+        d="M2 12a10 10 0 0 1 18-6"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M2 12a10 10 0 0 1 18-6"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path d="M2 16h.01" stroke-opacity="0.4" stroke-width="2" fill="none" />
+      <motion.path
+        d="M2 16h.01"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path
+        d="M21.8 16c.2-2 .131-5.354 0-6"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M21.8 16c.2-2 .131-5.354 0-6"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path
+        d="M5 19.5C5.5 18 6 15 6 12a6 6 0 0 1 .34-2"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M5 19.5C5.5 18 6 15 6 12a6 6 0 0 1 .34-2"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path
+        d="M8.65 22c.21-.66.45-1.32.57-2"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M8.65 22c.21-.66.45-1.32.57-2"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+
+      <path
+        d="M9 6.8a6 6 0 0 1 9 5.2v2"
+        stroke-opacity="0.4"
+        stroke-width="2"
+        fill="none"
+      />
+      <motion.path
+        d="M9 6.8a6 6 0 0 1 9 5.2v2"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/FishSymbol.vue
+++ b/app/components/Lucide/FishSymbol.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+  },
+  animate: {
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    transition: {
+      delay: 0.15,
+      opacity: { delay: 0.1 },
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="M2 16s9-15 20-4C11 23 2 8 2 8"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Flame.vue
+++ b/app/components/Lucide/Flame.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+    pathOffset: 0,
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.1,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.1 },
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        :variants="pathVariants"
+        :animate="currentState"
+        fill="none"
+        d="M8.9 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Frame.vue
+++ b/app/components/Lucide/Frame.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const defaultTransition = {
+  type: 'spring',
+  stiffness: 160,
+  damping: 17,
+  mass: 1,
+};
+
+const topLineVariants = {
+  normal: {
+    translateX: 0,
+    rotate: 0,
+    translateY: 0,
+  },
+  animate: { 
+    translateY: -4 
+  },
+};
+
+const bottomLineVariants = {
+  normal: {
+    translateX: 0,
+    rotate: 0,
+    translateY: 0,
+  },
+  animate: { 
+    translateY: 4 
+  },
+};
+
+const leftLineVariants = {
+  normal: {
+    translateX: 0,
+    rotate: 0,
+    translateY: 0,
+  },
+  animate: { 
+    translateX: -4 
+  },
+};
+
+const rightLineVariants = {
+  normal: {
+    translateX: 0,
+    rotate: 0,
+    translateY: 0,
+  },
+  animate: { 
+    translateX: 4 
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.line
+        :variants="topLineVariants"
+        :animate="currentState"
+        :transition="defaultTransition"
+        x1="22"
+        x2="2"
+        y1="6"
+        y2="6"
+      />
+      <motion.line
+        :variants="bottomLineVariants"
+        :animate="currentState"
+        :transition="defaultTransition"
+        x1="22"
+        x2="2"
+        y1="18"
+        y2="18"
+      />
+      <motion.line
+        :variants="leftLineVariants"
+        :animate="currentState"
+        :transition="defaultTransition"
+        x1="6"
+        x2="6"
+        y1="2"
+        y2="22"
+      />
+      <motion.line
+        :variants="rightLineVariants"
+        :animate="currentState"
+        :transition="defaultTransition"
+        x1="18"
+        x2="18"
+        y1="2"
+        y2="22"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Gauge.vue
+++ b/app/components/Lucide/Gauge.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const defaultTransition = {
+  type: 'spring',
+  stiffness: 160,
+  damping: 17,
+  mass: 1,
+};
+
+const pathVariants = {
+  normal: {
+    translateX: 0,
+    rotate: 0,
+    translateY: 0,
+  },
+  animate: { 
+    translateX: 0.5, 
+    translateY: 3, 
+    rotate: 72 
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="m12 14 4-4"
+        :variants="pathVariants"
+        :animate="currentState"
+        :transition="defaultTransition"
+      />
+      <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Github.vue
+++ b/app/components/Lucide/Github.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const bodyVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    scale: 1,
+    transition: {
+      duration: 0.3,
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    scale: [0.9, 1],
+    transition: {
+      duration: 0.4,
+    },
+  },
+};
+
+const tailVariants = {
+  normal: {
+    pathLength: 1,
+    rotate: 0,
+    transition: {
+      duration: 0.3,
+    },
+  },
+  draw: {
+    pathLength: [0, 1],
+    rotate: 0,
+    transition: {
+      duration: 0.5,
+    },
+  },
+  wag: {
+    pathLength: 1,
+    rotate: [0, -15, 15, -10, 10, -5, 5],
+    transition: {
+      duration: 2.5,
+      ease: 'easeInOut',
+      repeat: Infinity,
+    },
+  },
+};
+
+const isControlled = ref(false);
+const bodyState = ref('normal');
+const tailState = ref('normal');
+
+const startAnimation = async () => {
+  bodyState.value = 'animate';
+  tailState.value = 'draw';
+  
+  // Wait for draw animation to complete before starting wag
+  setTimeout(() => {
+    tailState.value = 'wag';
+  }, 500);
+};
+
+const stopAnimation = () => {
+  bodyState.value = 'normal';
+  tailState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"
+        :variants="bodyVariants"
+        :animate="bodyState"
+      />
+      <motion.path
+        d="M9 18c-4.51 2-5-2-7-2"
+        :variants="tailVariants"
+        :animate="tailState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Keyboard.vue
+++ b/app/components/Lucide/Keyboard.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+import { ref, watch } from 'vue';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const KEYBOARD_PATHS = [
+  { id: 'key1', d: 'M10 8h.01' },
+  { id: 'key2', d: 'M12 12h.01' },
+  { id: 'key3', d: 'M14 8h.01' },
+  { id: 'key4', d: 'M16 12h.01' },
+  { id: 'key5', d: 'M18 8h.01' },
+  { id: 'key6', d: 'M6 8h.01' },
+  { id: 'key7', d: 'M7 16h10' },
+  { id: 'key8', d: 'M8 12h.01' },
+];
+
+const isControlled = ref(false);
+const isHovered = ref(false);
+const keyStates = ref(KEYBOARD_PATHS.map(() => 'normal'));
+
+watch(isHovered, (value) => {
+  if (value) {
+    animateKeys();
+  } else {
+    keyStates.value = keyStates.value.map(() => 'normal');
+  }
+});
+
+const animateKeys = () => {
+  if (!isHovered.value) return;
+  
+  KEYBOARD_PATHS.forEach((_, index) => {
+    const delay = index * 0.2 * Math.random() * 1000;
+    
+    setTimeout(() => {
+      if (!isHovered.value) return;
+      keyStates.value[index] = 'highlight';
+      
+      setTimeout(() => {
+        if (!isHovered.value) return;
+        keyStates.value[index] = 'normal';
+        
+        setTimeout(() => {
+          if (!isHovered.value) return;
+          keyStates.value[index] = 'highlight';
+          
+          setTimeout(() => {
+            if (!isHovered.value) return;
+            keyStates.value[index] = 'normal';
+          }, 750);
+        }, 750);
+      }, 750);
+    }, delay);
+  });
+};
+
+const startAnimation = () => {
+  isHovered.value = true;
+};
+
+const stopAnimation = () => {
+  isHovered.value = false;
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect width="20" height="16" x="2" y="4" rx="2" />
+      <motion.path
+        v-for="(path, index) in KEYBOARD_PATHS"
+        :key="path.id"
+        :d="path.d"
+        :variants="{
+          normal: { opacity: 1 },
+          highlight: { opacity: 0.2 }
+        }"
+        :animate="keyStates[index]"
+        :transition="{
+          duration: 0.75,
+          ease: 'easeInOut',
+        }"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Languages.vue
+++ b/app/components/Lucide/Languages.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: { opacity: 1, pathLength: 1, pathOffset: 0 },
+  animate: { 
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+  },
+};
+
+const pathTransitions = [
+  {
+    opacity: { duration: 0.01, delay: 0 },
+    pathLength: {
+      type: 'spring',
+      duration: 0.5,
+      bounce: 0,
+      delay: 0,
+    },
+  },
+  {
+    opacity: { duration: 0.01, delay: 0.1 },
+    pathLength: {
+      type: 'spring',
+      duration: 0.5,
+      bounce: 0,
+      delay: 0.1,
+    },
+  },
+  {
+    opacity: { duration: 0.01, delay: 0.2 },
+    pathLength: {
+      type: 'spring',
+      duration: 0.5,
+      bounce: 0,
+      delay: 0.2,
+    },
+  },
+  {
+    opacity: { duration: 0.01, delay: 0.3 },
+    pathLength: {
+      type: 'spring',
+      duration: 0.5,
+      bounce: 0,
+      delay: 0.3,
+    },
+  },
+];
+
+const isControlled = ref(false);
+const pathStates = ref(['normal', 'normal', 'normal', 'normal', 'normal', 'normal']);
+
+const startAnimation = () => {
+  pathStates.value = pathStates.value.map(() => 'animate');
+};
+
+const stopAnimation = () => {
+  pathStates.value = pathStates.value.map(() => 'normal');
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="m5 8 6 6"
+        :variants="pathVariants"
+        :animate="pathStates[0]"
+        :transition="pathTransitions[3]"
+      />
+      <motion.path
+        d="m4 14 6-6 3-3"
+        :variants="pathVariants"
+        :animate="pathStates[1]"
+        :transition="pathTransitions[2]"
+      />
+      <motion.path
+        d="M2 5h12"
+        :variants="pathVariants"
+        :animate="pathStates[2]"
+        :transition="pathTransitions[1]"
+      />
+      <motion.path
+        d="M7 2h1"
+        :variants="pathVariants"
+        :animate="pathStates[3]"
+        :transition="pathTransitions[0]"
+      />
+      <motion.path
+        d="m22 22-5-10-5 10"
+        :variants="pathVariants"
+        :animate="pathStates[4]"
+        :transition="pathTransitions[3]"
+      />
+      <motion.path
+        d="M14 18h6"
+        :variants="pathVariants"
+        :animate="pathStates[5]"
+        :transition="pathTransitions[3]"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Link.vue
+++ b/app/components/Lucide/Link.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: { pathLength: 1, pathOffset: 0, rotate: 0 },
+  animate: {
+    pathLength: [1, 0.97, 1, 0.97, 1],
+    pathOffset: [0, 0.05, 0, 0.05, 0],
+    rotate: [0, -5, 0],
+    transition: {
+      rotate: {
+        duration: 0.5,
+      },
+      duration: 1,
+      times: [0, 0.2, 0.4, 0.6, 1],
+      ease: 'easeInOut',
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/LoaderPinwheel.vue
+++ b/app/components/Lucide/LoaderPinwheel.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const gVariants = {
+  normal: { rotate: 0 },
+  animate: {
+    rotate: 360,
+    transition: {
+      repeat: Infinity,
+      duration: 1,
+      ease: 'linear',
+    },
+  },
+};
+
+const defaultTransition = {
+  type: 'spring',
+  stiffness: 50,
+  damping: 10,
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.g
+        :transition="defaultTransition"
+        :variants="gVariants"
+        :animate="currentState"
+      >
+        <path d="M22 12a1 1 0 0 1-10 0 1 1 0 0 0-10 0" />
+        <path d="M7 20.7a1 1 0 1 1 5-8.7 1 1 0 1 0 5-8.6" />
+        <path d="M7 3.3a1 1 0 1 1 5 8.6 1 1 0 1 0 5 8.6" />
+      </motion.g>
+      <circle cx="12" cy="12" r="10" />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Play.vue
+++ b/app/components/Lucide/Play.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+import { ref } from 'vue';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    x: 0,
+    rotate: 0,
+  },
+  animate: {
+    x: [0, -1, 2, 0],
+    rotate: [0, -10, 0, 0],
+    transition: {
+      duration: 0.5,
+      times: [0, 0.2, 0.5, 1],
+      stiffness: 260,
+      damping: 20,
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.polygon
+        points="6 3 20 12 6 21 6 3"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Smile.vue
+++ b/app/components/Lucide/Smile.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const faceVariants = {
+  normal: { 
+    scale: 1,
+    rotate: 0,
+    strokeWidth: 2,
+    transition: { duration: 0.3, ease: "easeOut" }
+  },
+  animate: {
+    scale: [1, 1.15, 1.05, 1.1],
+    rotate: [0, -3, 3, 0],
+    strokeWidth: [2, 2.5, 2.5, 2.5],
+    transition: { 
+      duration: 0.8,
+      times: [0, 0.3, 0.6, 1],
+      ease: "easeInOut"
+    }
+  },
+};
+
+const mouthVariants = {
+  normal: { 
+    d: "M8 14s1.5 2 4 2 4-2 4-2",
+    pathLength: 1,
+    pathOffset: 0,
+    strokeWidth: 2,
+    transition: { duration: 0.3, ease: "easeOut" }
+  },
+  animate: {
+    d: "M7 13.5s2.5 3.5 5 3.5 5-3.5 5-3.5",
+    pathLength: [0.3, 1, 1],
+    pathOffset: [0, 0, 0],
+    strokeWidth: 2.5,
+    transition: { 
+      d: { duration: 0.4, ease: "easeOut" },
+      pathLength: { 
+        duration: 0.5, 
+        times: [0, 0.5, 1],
+        ease: "easeInOut"
+      },
+      delay: 0.1
+    }
+  },
+};
+
+const eyeVariants = {
+  normal: { 
+    scale: 1,
+    opacity: 1,
+    transition: { duration: 0.3, ease: "easeOut" }
+  },
+  animate: {
+    scale: [1, 1.5, 0.8, 1.2],
+    opacity: [1, 1, 1, 1],
+    transition: { 
+      duration: 0.5,
+      times: [0, 0.3, 0.6, 1],
+      ease: "easeInOut"
+    }
+  }
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.circle 
+        cx="12" 
+        cy="12" 
+        r="10"
+        :animate="currentState"
+        :variants="faceVariants"
+      />
+      <motion.path
+        :variants="mouthVariants"
+        :animate="currentState"
+        d="M8 14s1.5 2 4 2 4-2 4-2"
+      />
+      <motion.line 
+        x1="9" 
+        x2="9.01" 
+        y1="9" 
+        y2="9"
+        :variants="eyeVariants"
+        :animate="currentState"
+      />
+      <motion.line 
+        x1="15" 
+        x2="15.01" 
+        y1="9" 
+        y2="9"
+        :variants="eyeVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Terminal.vue
+++ b/app/components/Lucide/Terminal.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const lineVariants = {
+  normal: { opacity: 1 },
+  animate: {
+    opacity: [1, 0, 1],
+    transition: {
+      duration: 0.8,
+      repeat: Infinity,
+      ease: 'linear',
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="4 17 10 11 4 5" />
+      <motion.line
+        x1="12"
+        x2="20"
+        y1="19"
+        y2="19"
+        :variants="lineVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Timer.vue
+++ b/app/components/Lucide/Timer.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const handVariants = {
+  normal: {
+    rotate: 0,
+    originX: '12px',
+    originY: '14px',
+    transition: {
+      duration: 0.6,
+      ease: [0.4, 0, 0.2, 1],
+    },
+  },
+  animate: {
+    rotate: 300,
+    transition: {
+      delay: 0.1,
+      duration: 0.6,
+      ease: [0.4, 0, 0.2, 1],
+    },
+  },
+};
+
+const buttonVariants = {
+  normal: {
+    scale: 1,
+    y: 0,
+  },
+  animate: {
+    scale: [0.9, 1],
+    y: [0, 1, 0],
+    transition: {
+      duration: 0.3,
+      ease: [0.4, 0, 0.2, 1],
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.line
+        x1="10"
+        x2="14"
+        y1="2"
+        y2="2"
+        :animate="currentState"
+        :variants="buttonVariants"
+      />
+      <motion.line
+        x1="12"
+        x2="15"
+        y1="14"
+        y2="11"
+        :animate="currentState"
+        :variants="handVariants"
+      />
+      <circle cx="12" cy="14" r="8" />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/TrendingDown.vue
+++ b/app/components/Lucide/TrendingDown.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+import { ref } from 'vue';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const arrowVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [0.5, 0],
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.polyline
+        points="22 17 13.5 8.5 8.5 13.5 2 7"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+      <motion.polyline
+        points="16 17 22 17 22 11"
+        :variants="arrowVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/TrendingUp.vue
+++ b/app/components/Lucide/TrendingUp.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+import { ref } from 'vue';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const arrowVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [0.5, 0],
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.polyline
+        points="22 7 13.5 15.5 8.5 10.5 2 17"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+      <motion.polyline
+        points="16 7 22 7 22 13"
+        :variants="arrowVariants"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Upload.vue
+++ b/app/components/Lucide/Upload.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+import { ref } from 'vue';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const arrowVariants = {
+  normal: { y: 0 },
+  animate: {
+    y: -2,
+    transition: {
+      type: 'spring',
+      stiffness: 200,
+      damping: 10,
+      mass: 1,
+    },
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <motion.g
+        :variants="arrowVariants"
+        :animate="currentState"
+      >
+        <polyline points="17 8 12 3 7 8" />
+        <line x1="12" x2="12" y1="3" y2="15" />
+      </motion.g>
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/Wind.vue
+++ b/app/components/Lucide/Wind.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+import { ref } from 'vue';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const createPathVariants = (delay: number) => ({
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.3,
+      ease: 'easeInOut',
+      delay: delay,
+    },
+  },
+  animate: {
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.5,
+      ease: 'easeInOut',
+      delay: delay,
+    },
+  },
+});
+
+const pathVariants1 = createPathVariants(0.2);
+const pathVariants2 = createPathVariants(0);
+const pathVariants3 = createPathVariants(0.4);
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="M12.8 19.6A2 2 0 1 0 14 16H2"
+        :variants="pathVariants1"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M17.5 8a2.5 2.5 0 1 1 2 4H2"
+        :variants="pathVariants2"
+        :animate="currentState"
+      />
+      <motion.path
+        d="M9.8 4.4A2 2 0 1 1 11 8H2"
+        :variants="pathVariants3"
+        :animate="currentState"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/components/Lucide/X.vue
+++ b/app/components/Lucide/X.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { motion } from 'motion-v';
+import { ref } from 'vue';
+
+interface Props {
+  size?: number;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 28,
+  class: '',
+});
+
+const emit = defineEmits<{
+  startAnimation: [];
+  stopAnimation: [];
+}>();
+
+const pathVariants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+  },
+};
+
+const isControlled = ref(false);
+const currentState = ref('normal');
+
+const startAnimation = () => {
+  currentState.value = 'animate';
+};
+
+const stopAnimation = () => {
+  currentState.value = 'normal';
+};
+
+const handleMouseEnter = () => {
+  if (!isControlled.value) {
+    startAnimation();
+  } else {
+    emit('startAnimation');
+  }
+};
+
+const handleMouseLeave = () => {
+  if (!isControlled.value) {
+    stopAnimation();
+  } else {
+    emit('stopAnimation');
+  }
+};
+
+defineExpose({
+  startAnimation,
+  stopAnimation,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+      props.class,
+    ]"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="size"
+      :height="size"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <motion.path
+        d="M18 6 6 18"
+        :variants="pathVariants"
+        :animate="currentState"
+      />
+      <motion.path
+        d="m6 6 12 12"
+        :variants="pathVariants"
+        :animate="currentState"
+        :transition="{ delay: 0.2 }"
+      />
+    </svg>
+  </div>
+</template> 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -755,6 +755,231 @@
           />
         </template>
       </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCheck
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideGithub
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCompass
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideFlame
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideFingerprint
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideFishSymbol
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideEyeOff
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideCopy
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideChevronDown
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideExpand
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideFrame
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideGauge
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideKeyboard
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideLoaderPinwheel
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideLanguages
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideLink
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideSmile
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideTerminal
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideTimer
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideTrendingUp
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideTrendingDown
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideWind
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideUpload
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucideX
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
+      <AnimatedIconButton>
+        <template #default="{ ref, controlled }">
+          <LucidePlay
+            :ref="ref"
+            :controlled="controlled"
+            :class="primaryColor"
+          />
+        </template>
+      </AnimatedIconButton>
     </div>
   </UContainer>
 </template>


### PR DESCRIPTION
This PR adds the following icons:

```
- Check
- ChevronDown
- Compass
- Copy
- Expand
- EyeOff
- Fingerprint
- FishSymbol
- Flame
- Frame
- Gauge
- Github
- Keyboard
- Languages
- Link
- LoaderPinwheel
- Play
- Smile
- Terminal
- Timer
- TrendingDown
- TrendingUp
- Upload
- Wind
- X
```

Thanks to joeelia's cursor rule it was pretty straight forward to add them!

I just want to add that by enabling YOLO mode you can make cursor automatically download the react component by making curl calls to https://icons.pqoqubbw.dev/c/[iconname].json 